### PR TITLE
Fix German mask designer layout overflow

### DIFF
--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -171,12 +171,12 @@ maskDesigner.spotfieldWidthLabel.text=Breite
 maskDesigner.spotHeightLabel.text=Formhöhe
 maskDesigner.spotWidthLabel.text=Formbreite
 maskDesigner.superGridColumnsLabel.text=Spalten
-maskDesigner.superGridDescription.text=Das übergeordnete Gitter, auf dem die einzelnen Spotfelder platziert sind
+maskDesigner.superGridDescription.text=Das Basisgitter, bestehend aus Spotfeldern.
 maskDesigner.superGridHeader.text=Superraster
 maskDesigner.superGridRowsLabel.text=Reihen
 maskDesigner.uniformIntersections.text=Alle Schnittpunkte bearbeiten
-maskDesigner.uniformIntersectionsDescription.text=Wenn ausgewählt, ist der Abstand zwischen allen Spotfeldern einheitlich breit. \
-    Andernfalls können spezifsche Abstände über ihre Intersektionen individuell eingestellt werden.
+maskDesigner.uniformIntersectionsDescription.text=Wenn ausgewählt, ist der Abstand zwischen allen Spotfeldern einheitlich. \
+    Andernfalls können die Abstände individuell eingestellt werden.
 maskDesigner.verticalSpacingLabel.text=Vertikaler Abstand
 maskDesigner.widthLabel.text=Breite
 maskDesigner.xInsetLabel.text=X-Inset


### PR DESCRIPTION
In the center column, some help texts were taking too much space causing the UI to overflow. I shortened the German texts. Although this is not ideal and in theory the auto-layouting should increase the designer height instead, the `GridBagLayout` does not do so which is why I opted for this solution.